### PR TITLE
fix: ShareExt.entitlements

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ cordova plugin add cc.fovea.cordova.openwith \
 | `IOS_URL_SCHEME` | uniquelonglowercase | **iOS only** Any random long string of lowercase alphabetical characters |
 | `IOS_UNIFORM_TYPE_IDENTIFIER` | public.image | **iOS only** UTI of documents you want to share, e.g. `public.image`, `public.movie`, `public.url`, `public.plain-text` or `public.item` for all UTIs (check [Apple's System-Declared UTI](https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html#//apple_ref/doc/uid/TP40009259-SW1)) |
 | `IOS_GROUP_IDENTIFIER` | group.my.app.id | **iOS only** Custom app group name. Default is `group.<YOUR_APP_BUNDLE_ID>.shareextension`. |
-| `SHAREEXT_PROVISIONING_PROFILE` | 9dfsdf-.... | **iOS only** UUID of provisioning profile for singing |
 | `SHAREEXT_DEVELOPMENT_TEAM` | 00B000A09l | **iOS only** Developer account teamId |
 
 It shouldn't be too hard. But just in case, I [posted a screencast of it](https://youtu.be/eaE4m_xO1mg).

--- a/hooks/iosAddTarget.js
+++ b/hooks/iosAddTarget.js
@@ -346,11 +346,10 @@ module.exports = function (context) {
     var customTemplateKey = pbxProject.findPBXGroupKey({name: 'CustomTemplate'});
     pbxProject.addFile('ShareExt.entitlements', customTemplateKey, { lastKnownFileType: 'text.plist.entitlements' });
 
-    //Add development team and provisioning profile
-    var PROVISIONING_PROFILE = getCordovaParameter(configXml, 'SHAREEXT_PROVISIONING_PROFILE');
+    // Add development team
     var DEVELOPMENT_TEAM = getCordovaParameter(configXml, 'SHAREEXT_DEVELOPMENT_TEAM');
-    console.log('Adding team', DEVELOPMENT_TEAM, 'and provisoning profile', PROVISIONING_PROFILE);
-    if (PROVISIONING_PROFILE && DEVELOPMENT_TEAM) {
+    console.log('Adding team', DEVELOPMENT_TEAM);
+    if (DEVELOPMENT_TEAM) {
       var configurations = pbxProject.pbxXCBuildConfigurationSection();
       for (var key in configurations) {
         if (typeof configurations[key].buildSettings !== 'undefined') {
@@ -358,10 +357,10 @@ module.exports = function (context) {
           if (typeof buildSettingsObj['PRODUCT_NAME'] !== 'undefined') {
             var productName = buildSettingsObj['PRODUCT_NAME'];
             if (productName.indexOf('ShareExt') >= 0) {
-              buildSettingsObj['PROVISIONING_PROFILE'] = PROVISIONING_PROFILE;
               buildSettingsObj['DEVELOPMENT_TEAM'] = DEVELOPMENT_TEAM;
-              buildSettingsObj['CODE_SIGN_STYLE'] = 'Manual';
-              buildSettingsObj['CODE_SIGN_IDENTITY'] = '"iPhone Distribution"';
+              buildSettingsObj['CODE_SIGN_STYLE'] = 'Automatic';
+              buildSettingsObj['CODE_SIGN_IDENTITY'] = '"Apple Development"';
+              buildSettingsObj['CODE_SIGN_ENTITLEMENTS'] = 'ShareExt.entitlements';
               console.log('Added signing identities for extension!');
             }
           }

--- a/hooks/iosAddTarget.js
+++ b/hooks/iosAddTarget.js
@@ -53,7 +53,7 @@ function arrayFilterUnique(value, index, self) {
 
 function addEntitlments(filePath, preferences) {
     var plist = require('plist');
-    var plistContent = plist.parse(fs.readFileSync(filePath, 'utf8'));
+    var plistContent = fs.existsSync(filePath) ? plist.parse(fs.readFileSync(filePath, 'utf8')) : {};
     var parent = 'com.apple.security.application-groups';
     for (var i = 0; i < preferences.length; i++) {
         var pref = preferences[i];
@@ -341,6 +341,10 @@ module.exports = function (context) {
     // Add App Group to entitlments
     addEntitlments(path.join(iosFolder(context), projectName, 'Entitlements-Debug.plist'), preferences);
     addEntitlments(path.join(iosFolder(context), projectName, 'Entitlements-Release.plist'), preferences);
+    // ShareExt.entitlments is needed and must be linked to root project
+    addEntitlments(path.join(iosFolder(context), 'ShareExt.entitlements'), preferences);
+    var customTemplateKey = pbxProject.findPBXGroupKey({name: 'CustomTemplate'});
+    pbxProject.addFile('ShareExt.entitlements', customTemplateKey, { lastKnownFileType: 'text.plist.entitlements' });
 
     //Add development team and provisioning profile
     var PROVISIONING_PROFILE = getCordovaParameter(configXml, 'SHAREEXT_PROVISIONING_PROFILE');


### PR DESCRIPTION
Currently, the Share Extension does not include the correct app groups in its configuration. This is resolved by adding a `ShareExt.entitlements` file at the root of the XCode project.

The file must include the group identifier (the existing `addEntitlments()` function does exactly that) and be registered in the xcode project file.

It's a new file so `addEntitlments()` is modified to allow file creation.

The file must also be registered in the signing part of the configuration, so we update it to reflect its actual use (automatic signing without a provisioning profile).

With this PR, the share extension and the app are signed and built correctly in XCode. 

-----

- ShareExt.entitlements file is needed for the app group property to be kept on build
- Fix automatic code signing